### PR TITLE
enabling awx user escalation capabilities

### DIFF
--- a/roles/ami_config/tasks/ami-rh-container/ami-rh-container-lab.yml
+++ b/roles/ami_config/tasks/ami-rh-container/ami-rh-container-lab.yml
@@ -1,7 +1,7 @@
 ---
 # Test to create a ocp file
 
-- include: rh_subscription.yml
+- include: ../subscriptions/rh_subscription.yml
 
     #### TODO check out blocks.
 

--- a/roles/ami_config/tasks/ami-tower/install.yml
+++ b/roles/ami_config/tasks/ami-tower/install.yml
@@ -83,4 +83,34 @@
     password: "{{ tower_password }}"
     body: '{{ lookup("file", tower_license) }}'
     body_format: json
+
+- name: See if the sudo escalation is already there
+  shell: grep "AWX_PROOT_ENABLED=False" /etc/tower/settings.py
+  register: aws_enabled
+
+- name: Enable sudo escalation for Tower
+  lineinfile:
+    path: /etc/tower/settings.py
+    line: "AWX_PROOT_ENABLED=False"
+    backup: yes
+  when: aws_enabled.stdout != ""
+  become: true
+
+- name: Allow 'wheel' group to have passwordless sudo
+  lineinfile:
+    dest: /etc/sudoers
+    state: present
+    regexp: '^%wheel'
+    line: '%wheel ALL=(ALL) NOPASSWD: ALL'
+    validate: visudo -cf %s
+  become: true
+
+- name: Add sudoers users to wheel group
+  user:
+    name: "{{ item }}"
+    groups: wheel
+    append: yes
+  with_items: 
+    - awx
+  become: true
 ...

--- a/roles/ami_config/tasks/ami-tower/install.yml
+++ b/roles/ami_config/tasks/ami-tower/install.yml
@@ -85,15 +85,16 @@
     body_format: json
 
 - name: See if the sudo escalation is already there
-  shell: grep "AWX_PROOT_ENABLED=False" /etc/tower/settings.py
+  command: grep "AWX_PROOT_ENABLED=False" /etc/tower/settings.py
   register: aws_enabled
+  ignore_errors: yes
 
 - name: Enable sudo escalation for Tower
   lineinfile:
     path: /etc/tower/settings.py
     line: "AWX_PROOT_ENABLED=False"
     backup: yes
-  when: aws_enabled.stdout != ""
+  when: aws_enabled.rc != 0
   become: true
 
 - name: Allow 'wheel' group to have passwordless sudo

--- a/roles/ami_config/tasks/main.yml
+++ b/roles/ami_config/tasks/main.yml
@@ -8,6 +8,6 @@
 - import_tasks: ami-tower/ami-tower.yml
   when: ami_config == "tower"
 
-- include: ami-ami-rh-container/ami-rh-container-lab.yml
+- include: ami-rh-container/ami-rh-container-lab.yml
   when: ami_config == "rh-container-lab"
 ...


### PR DESCRIPTION
To test, just build a tower AMI.

then launch it with https://github.com/sabre1041/managing-ocp-install-beyond

then, you have to launch an OCP instance.

This PR addresses leftover work from: https://github.com/sabre1041/managing-ocp-install-beyond/pull/164

I tested this all the way through from building AMI to launching 3.9.