### PR TITLE
Correct static name from ami_tower to generic ami_name

### DIFF
--- a/ami_lab_launch.yml
+++ b/ami_lab_launch.yml
@@ -5,6 +5,11 @@
   strategy: debug
   vars_files:
     - aws_vars.yml
+  pre_tasks:
+  - name: Check if 'ami_config' is defined
+    fail:
+      msg: "ERROR! The variable 'ami_config' must be defined!"
+    when: not ami_config is defined
   tasks:
   - name: Provision AMI instance on AWS for "{{ ami_config }}"
     ec2:
@@ -16,7 +21,7 @@
       image: "{{ rhel_ami_id }}"
       wait: yes
       instance_tags:
-        Name: "ami-{{ ami_user }}-{{ ami_config }}-{{ ami_unique_id }}.{{ domain_name }}"
+        Name: "ami-{{ ami_user }}-{{ ami_name }}.{{ domain_name }}"
         ami_user: "{{ ami_user }}"
         ami_config: "{{ ami_config }}"
         student_id: "{{ ami_user }}-ami"

--- a/aws_vars.yml
+++ b/aws_vars.yml
@@ -1,15 +1,6 @@
 ---
-## Count of Tower instances to instantiate
-ami_count: 1
-# These are normally set to start at 1 and end at {{ student_count }} but can be customized as needed
-ami_count_start: 1
-ami_count_end: "{{ ami_count }}"
-
 # Default names of the AMIs that we create
-ami_ocp: ami_ocp-{{ ami_unique_id }}
-ami_tower: ami_tower-{{ ami_unique_id }}
-ami_http: ami_http-{{ ami_unique_id }}
-ami_container: ami_rh-container-{{ ami_unique_id }}
+ami_name: "{{ ami_config + '-' + ami_unique_id }}"
 
 # Set the default AMI root disk size
 ami_root_disk_size: 25

--- a/roles/ami_config/tasks/create_ami.yml
+++ b/roles/ami_config/tasks/create_ami.yml
@@ -33,7 +33,7 @@
     aws_access_key: "{{ ec2_access_key }}"
     aws_secret_key: "{{ ec2_secret_key }}"
     instance_id: "{{ instance_id }}"
-    name: "{{ ami_tower }}"
+    name: "{{ ami_name }}"
     region: "{{ aws_region }}"
     wait: yes
   register: ami_id

--- a/secrets.yml
+++ b/secrets.yml
@@ -12,9 +12,6 @@ ami_config: ocp
 
 # The ami_user parameter can be set to anything. While doing active development, you can set it to your username and the type of AMI you are building to differentiate what you are doing from other developers building AMIs in the same AWS region.
 ami_user: ocp-test
-
-# The ami_count variable should generally be left at 1.
-ami_count: 1
 # END of General parameters that determine how your AMI will be configured.
 
 # When building the same AMI over and over, increment the student count to give the VM a new name so DNS works properly. You must increment this variable each time you run AAB.


### PR DESCRIPTION
* Cleaned up aws_vars file to use new ami_name variable
* Cleaned up secrets file
* Added check for ami_config variable defined

To test, run any ami profile. Also, feel free to test what happens if you don't specify `ami_config` as such (note, do not include any secrets file):

`ansible-playbook ami_lab_launch.yml`